### PR TITLE
Release 0.3.0: Migração para JUnit 6 e melhorias na stack de testes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# Copilot Instructions
+
+Resumo das regras do projeto para o Copilot. Sempre priorizar estas diretrizes ao sugerir código.
+
+## Estilo de Código
+
+- **Sem comentários em código**
+  - Não gerar `//`, `/* */` ou `/** */` em Java ou outros arquivos de produção e teste.
+  - Prefira nomes claros de classes, métodos e variáveis em vez de comentários.
+
+- **Nomes descritivos e Clean Code**
+  - Métodos curtos, com responsabilidade única.
+  - Evitar abreviações não óbvias.
+  - Usar tipos imutáveis e coleções imutáveis sempre que fizer sentido.
+
+- **Tratamento de erros**
+  - Não engolir exceções; sempre propagar ou tratar com mensagem clara.
+  - Evitar lançar `RuntimeException` genérica; criar exceções de domínio específicas.
+
+## Arquitetura
+
+- **Use Cases em vez de Services genéricos**
+  - Cada caso de uso em uma classe dedicada (`CreateOrderUseCase`, `GetOrderUseCase`, etc.).
+  - Injetar dependências via construtor (DIP).
+
+- **Domínio rico**
+  - Colocar regras de negócio nas entidades/objetos de domínio (`Pedido`, `ItemDePedido`).
+  - Evitar modelos anêmicos apenas com getters/setters.
+
+- **Padrões**
+  - Quando houver muitos `if` ou `switch`, considerar Strategy, Factory, State, Chain of Responsibility ou Specification, conforme apropriado.
+
+## Testes
+
+- **TDD sempre que possível**
+  - Criar ou ajustar testes antes de implementar mudanças em regras de negócio.
+  - Para correções de bug, primeiro reproduzir com um teste que falha.
+
+- **Cobertura de regras críticas**
+  - Focar em autenticação/autorização (quando existir), validações, integrações externas e cálculos de valores.
+
+## Qualidade Estática
+
+- **Checkstyle**
+  - Respeitar `CustomImportOrder`:
+    - Grupo `java.*`, depois `jakarta.*` e demais terceiros (`org.*`, etc.).
+    - Por último `com.poc.delivery.*` em grupo separado por linha em branco.
+    - Não usar imports com `*`.
+
+- **SonarQube**
+  - Evitar variáveis locais não usadas ou atribuições inúteis.
+  - Manter complexidade de métodos baixa; sugerir extração de métodos quando necessário.
+
+## Logging e Segurança
+
+- Usar `LogEvent` para logs relevantes de domínio (`ORDER_CREATED`, `ORDER_RETRIEVED`, etc.).
+- Não logar dados sensíveis (tokens, senhas, cookies). Quando necessário, mascarar.
+- Em filtros HTTP, seguir o padrão existente de redigir headers sensíveis.
+
+## Documentação e Collections
+
+- Atualizar `CHANGELOG.md` em linguagem focada no usuário quando adicionar funcionalidades relevantes.
+- Para novos endpoints REST, alinhar com o guia `Criacao-de-Endpoint.md` e, se fizer sentido, adicionar request correspondente nas collections do Bruno.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,48 @@
+# Backend Instructions
+
+Regras para o Copilot ao sugerir código Java/Spring Boot neste repositório.
+
+## Arquitetura
+
+- Usar **Use Cases** em vez de `*Service` genéricos.
+  - Ex.: `CreateOrderUseCase`, `GetOrderUseCase`.
+  - Uma ação por use case, método principal `execute(...)`.
+- Depender de **abstrações**, não de implementações concretas.
+  - Repositórios via interfaces Spring Data ou portas claras.
+- Manter o **domínio rico**:
+  - Regras de negócio em `Pedido`, `ItemDePedido`, etc.
+  - Métodos de comportamento (`confirmar()`, `cancelar()`) em vez de ifs espalhados.
+
+## Estilo de Código
+
+- **Sem comentários** em código de produção e testes.
+- Nomes claros e em português para métodos e variáveis.
+- Métodos curtos, responsabilidade única; extrair métodos auxiliares quando necessário.
+- Evitar `null` desnecessário; preferir tipos obrigatórios e validações antecipadas.
+
+## Validação e Erros
+
+- Validar entrada em bordas públicas (controllers, use cases, validators dedicados).
+- Usar exceções específicas de domínio (ex.: `OrderNotFoundException`).
+- Não lançar `RuntimeException` genérica.
+- Não engolir exceções; logar com contexto e, se necessário, mapear para erro HTTP via `GlobalExceptionHandler`.
+
+## Logging
+
+- Usar `LogEvent` para logs importantes:
+  - `ORDER_CREATED`, `ORDER_RETRIEVED`, `ORDER_NOT_FOUND`, `ORDER_UNEXPECTED_ERROR`, etc.
+- Não logar dados sensíveis (tokens, senhas, cookies). Quando precisar, mascarar.
+
+## Integração com Infra
+
+- Ao usar repositórios JPA:
+  - Entidades em `infrastructure.persistence.entity`.
+  - Mapeamentos via `PedidoMapper`/MapStruct para converter entre domínio e entidade.
+- Não acessar diretamente HTTP, banco ou outras infra do domínio; use portas/abstrações.
+
+## Qualidade
+
+- Respeitar Checkstyle e Sonar:
+  - Ordem de imports via `CustomImportOrder` (java → terceiros → `com.poc.delivery.*`).
+  - Evitar variáveis não usadas e código morto.
+- Manter complexidade baixa; extrair pequenas funções quando o método ficar grande.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "app/src/main/java/**/*.java"
+---
+
 # Backend Instructions
 
 Regras para o Copilot ao sugerir código Java/Spring Boot neste repositório.

--- a/.github/instructions/infra.instructions.md
+++ b/.github/instructions/infra.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "scripts/**/*.sh,infra/**"
+---
+
 # Infra Instructions
 
 Regras para o Copilot ao sugerir scripts e infraestrutura neste repositório.

--- a/.github/instructions/infra.instructions.md
+++ b/.github/instructions/infra.instructions.md
@@ -1,0 +1,43 @@
+# Infra Instructions
+
+Regras para o Copilot ao sugerir scripts e infraestrutura neste repositório.
+
+## Scripts (shell)
+
+- Usar `bash` com `set -e` ou `set -euo pipefail` em scripts críticos.
+- Sempre detectar diretório base com padrão seguro:
+  - `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"`
+  - `PROJECT_DIR="${SCRIPT_DIR}/.."`
+- Não hardcodar caminhos absolutos; trabalhar relativo à raiz do projeto.
+- Mensagens de saída claras, em português, indicando passos e erros.
+
+## Sonar e Qualidade
+
+- Reutilizar o padrão do `scripts/sonar-local.sh`:
+  - Verificar Docker.
+  - Subir container SonarQube se necessário.
+  - Rodar `./gradlew clean build` antes da análise.
+  - Chamar o `sonar-scanner` a partir da raiz do projeto.
+  - Consultar a API do Sonar e falhar se houver issues não resolvidas.
+- Quando listar issues ou violações, incluir ao menos:
+  - Severidade, tipo, arquivo, linha, mensagem.
+
+## Checkstyle / Jacoco
+
+- Não alterar `config/checkstyle/checkstyle.xml` de forma a relaxar regras principais (sem combinar com o time).
+- Ao sugerir mudanças em cobertura de testes:
+  - Usar testes adicionais antes de mexer em limites do Jacoco.
+
+## Segurança e Logs
+
+- Em scripts ou configs, evitar expor credenciais sensíveis em texto plano.
+  - Preferir variáveis de ambiente quando possível.
+- Para logs HTTP:
+  - Seguir o padrão de `HttpRequestLoggingFilter` (mascarar headers como `authorization` e `cookie`).
+
+## Docker / Infra Local
+
+- Se sugerir novos serviços Docker, manter coerência com o padrão atual:
+  - Usar imagens oficiais e leves (ex.: `postgres:16-alpine`).
+  - Configurar portas e volumes de forma explícita.
+- Scripts não devem depender de ferramentas externas não documentadas (instalar via README se for o caso).

--- a/.github/instructions/test.instructions.md
+++ b/.github/instructions/test.instructions.md
@@ -16,7 +16,7 @@ Diretrizes para o Copilot ao sugerir testes neste repositório.
 
 ## Ferramentas e Stack
 
-- **JUnit 5** (`@Test`, `@BeforeEach`, tags quando necessário).
+- **JUnit 6 (Jupiter)** (`@Test`, `@BeforeEach`, tags quando necessário).
 - **Mockito** para mocks e stubs.
 - **Instancio** para geração de dados em testes complexos.
 - **Spring Boot Test + Testcontainers** para testes de integração (já configurados em `DeliveryApplicationTests` e `OrderControllerIT`).

--- a/.github/instructions/test.instructions.md
+++ b/.github/instructions/test.instructions.md
@@ -1,0 +1,65 @@
+# Test Instructions
+
+Diretrizes para o Copilot ao sugerir testes neste repositório.
+
+## Princípios Gerais
+
+- Priorizar **TDD**:
+  - Sempre que possível, sugerir primeiro o teste que falha antes da implementação.
+  - Para bugs, criar um teste que reproduza o erro antes do fix.
+- Testes devem ser **claros e focados** em uma regra de negócio.
+- Usar **nomes descritivos** de métodos de teste (em português) que indiquem o cenário e o resultado esperado.
+
+## Ferramentas e Stack
+
+- **JUnit 5** (`@Test`, `@BeforeEach`, tags quando necessário).
+- **Mockito** para mocks e stubs.
+- **Instancio** para geração de dados em testes complexos.
+- **Spring Boot Test + Testcontainers** para testes de integração (já configurados em `DeliveryApplicationTests` e `OrderControllerIT`).
+
+## Estrutura dos Testes
+
+- Testes unitários devem isolar o use case ou componente sob teste:
+  - Mockar dependências externas (repositórios, mappers, serviços externos).
+  - Verificar interações essenciais com `Mockito.verify(...)` quando fizer sentido.
+- Testes de integração devem:
+  - Subir o contexto Spring Boot.
+  - Usar Testcontainers para banco de dados.
+  - Exercitar a API via `MockMvc` ou `RestAssured`, conforme o padrão existente.
+
+## Padrões de Nomenclatura
+
+- Classes de teste terminam com `Test` (ex.: `CreateOrderUseCaseTest`, `OrderControllerTest`).
+- Métodos de teste seguem padrão descritivo, por exemplo:
+  - `deveCriarPedidoComSucesso()`
+  - `deveLancarExcecaoQuandoPedidoNaoEncontrado()`
+- Evitar comentários dentro dos testes; o nome do método deve explicar o cenário.
+
+## Cobertura e Qualidade
+
+- Focar em cobrir:
+  - Regras de negócio em use cases.
+  - Validações de entrada (DTOs, validators).
+  - Integrações com repositórios (via mocks ou integração).
+- Evitar testes frágeis:
+  - Não acoplar a detalhes de implementação que podem mudar facilmente.
+  - Verificar apenas o que é relevante para o comportamento.
+
+## Boas Práticas Específicas
+
+- **Use Cases**:
+  - Testar fluxos felizes e fluxos de erro previsíveis (ex.: not found, validação, limites).
+  - Garantir que exceções de domínio corretas são lançadas com mensagens significativas.
+- **Controllers**:
+  - Usar `MockMvc` para validar status HTTP, payload e contrato de erro (`error.code`, `error.message`).
+  - Incluir `GlobalExceptionHandler` nos testes de controller.
+- **Entidades de domínio**:
+  - Testar comportamento (métodos que alteram estado), não apenas getters/setters.
+- **Filtros / Infra**:
+  - Em filtros HTTP, testar logging e mascaramento de dados sensíveis sem depender de logs reais.
+
+## Restrições
+
+- Não gerar comentários (`//`, `/* */`, `/** */`) dentro dos testes.
+- Não sugerir código que quebre Checkstyle, Sonar ou as regras de import definidas.
+- Não criar testes vazios ou gerados automaticamente sem asserções significativas.

--- a/.github/instructions/test.instructions.md
+++ b/.github/instructions/test.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "app/src/test/java/**/*.java"
+---
+
 # Test Instructions
 
 Diretrizes para o Copilot ao sugerir testes neste repositório.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-11-26
+
+### Added
+
+- ✅ **Guia de Migração e Uso do JUnit 6**
+  - Novo documento `app/docs/guide/JUnit6.md` explicando objetivos, vantagens e principais novidades do JUnit 6.
+  - Passo a passo para migrar projetos existentes de JUnit 5 para JUnit 6, com foco em Java 17+.
+  - Exemplos práticos de configuração com Gradle (BOM do JUnit, tasks e tags).
+
+- 📚 **Documentação aprimorada de assertions**
+  - Guia `assertThat-vs-junit-assertions.md` atualizado para comparar AssertJ com as assertions nativas do JUnit 5/6.
+  - Tabelas detalhadas mostrando o que cada abordagem oferece (coleções, mensagens de erro, soft assertions, BDD, etc.).
+
+### Changed
+
+- 🧪 **Stack de testes atualizada para JUnit 6**
+  - Projeto agora utiliza o BOM `org.junit:junit-bom:6.0.1`, alinhando Platform, Jupiter e Vintage na mesma versão.
+  - Testes existentes migrados para rodar sobre JUnit 6 sem quebra de regras de negócio.
+
+- 🔀 **Separação clara entre testes unitários e de integração**
+  - Configuração Gradle ajustada para usar tags do JUnit Jupiter:
+    - `:app:test` executa apenas testes sem `@Tag("integration")`.
+    - `:app:integrationTest` executa somente testes anotados com `@Tag("integration")` (por exemplo, `OrderControllerIT` e `DeliveryApplicationTests`).
+  - Testes de integração utilizam Testcontainers e dependem explicitamente de Docker, evitando falhas locais em execuções unitárias.
+
 ## [0.2.0] - 2025-11-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Para mais exemplos, consulte [`collections/`](collections/) e [`historias/fase1/
 
 ### Testes
 
-- **JUnit 5** - Framework de testes
+- **JUnit 6 (Jupiter)** - Framework de testes
 - **AssertJ** - Assertions fluentes
 - **Testcontainers** - Testes de integração com containers
 - **Cucumber** - BDD (Behavior-Driven Development)
@@ -340,7 +340,7 @@ open app/build/reports/jacoco/test/html/index.html
 
 - **Testes Unitários:** `app/src/test/java`
 - **Cobertura Atual:** 100%
-- **Framework:** JUnit 5 + AssertJ
+- **Framework:** JUnit 6 + AssertJ
 
 ### Executar Testes
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.poc'
-version = '0.2.0'
+version = '0.3.0'
 
 java {
     toolchain {
@@ -33,6 +33,12 @@ tasks.register('integrationTest', Test) {
 
 repositories {
     mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.junit:junit-bom:6.0.1"
+    }
 }
 
 def testcontainersVersion = '1.21.3'
@@ -113,7 +119,8 @@ jacocoTestCoverageVerification {
             excludes = [
                 'com.poc.delivery.DeliveryApplication',  // Exclui entry point
                 'com.poc.delivery.common.FlywayConfig',  // Exclui configuração de infra
-                'com.poc.delivery.common.logging.HttpRequestLoggingFilter'  // Exclui filtro de logging
+                'com.poc.delivery.common.logging.HttpRequestLoggingFilter',  // Exclui filtro de logging
+                'com.poc.delivery.api.OpenApiConfig'  // Exclui configuração de OpenAPI (infra)
             ]
         }
     }

--- a/app/docs/guide/JUnit6.md
+++ b/app/docs/guide/JUnit6.md
@@ -1,0 +1,286 @@
+# JUnit 6 – Visão Geral, Vantagens e Migração a partir do JUnit 5
+
+## 1. Introdução
+
+O JUnit 6 é a evolução natural do JUnit 5, mantendo o modelo de plataforma (Platform, Jupiter e Vintage), mas com foco em:
+
+- **Limpeza de APIs antigas** e remoção de comportamentos legados.
+- **Modernização da base de execução** (Java 17+, Kotlin 2.2+).
+- **Unificação de versões** entre os módulos principais.
+- **Melhor suporte a nullability**, paralelismo e ferramentas modernas.
+
+O objetivo desta página é servir como guia rápido para o time entender **por que** considerar o JUnit 6 e **como** migrar gradualmente a suíte atual baseada em JUnit 5.
+
+---
+
+## 2. Objetivos do JUnit 6
+
+- **Modernizar o baseline da plataforma**
+  - Java 17 como versão mínima suportada.
+  - Kotlin 2.2 como versão mínima suportada (para cenários com Kotlin).
+
+- **Unificar a versão dos módulos principais**
+  - Plataforma, Jupiter e Vintage passam a compartilhar o **mesmo número de versão** (ex.: `6.0.x`).
+  - Facilita alinhamento de dependências e troubleshooting.
+
+- **Melhorar a capacidade de evolução da API**
+  - Uso sistemático de anotações de nullability via [JSpecify](https://jspecify.dev/).
+  - Foco em remover APIs obsoletas e comportamentos ambíguos herdados de versões anteriores.
+
+- **Aprimorar a experiência de execução de testes**
+  - Integração de funcionalidades de JFR (Java Flight Recorder) no `junit-platform-launcher`.
+  - Novos recursos de controle de execução (ex.: *fail-fast* e `CancellationToken`).
+
+---
+
+## 3. Vantagens do JUnit 6 em relação ao JUnit 5
+
+- **Base de linguagem atualizada**
+  - Garante que os testes rodam em ambientes compatíveis com as versões modernas de Java e Kotlin.
+  - Evita problemas de compatibilidade com bibliotecas que já assumem Java 17+.
+
+- **Menos "lixo" histórico na API**
+  - Remoção de diversas APIs marcadas como deprecated na série 5.x.
+  - Comportamentos ambíguos ou legados são simplificados ou removidos.
+
+- **Modelo de versão mais simples**
+  - Uma única versão para Platform, Jupiter e Vintage reduz o risco de misturar combinações incompatíveis.
+
+- **Nullability melhor documentada**
+  - Anotações JSpecify ajudam a entender melhor o contrato das APIs (o que pode ser nulo, o que não pode).
+  - Facilita uso em IDEs e ferramentas de análise estática.
+
+- **Melhorias pontuais na execução de testes**
+  - Ordem determinística para classes anotadas com `@Nested`.
+  - Novos orderers padrão (`MethodOrderer.Default`, `ClassOrderer.Default`).
+  - Suporte aprimorado a CSV em testes parametrizados.
+  - Melhor suporte a `suspend` functions em Kotlin como métodos de teste.
+
+---
+
+## 4. Principais novidades técnicas
+
+### 4.1 Baseline de plataforma
+
+- **Java 17 mínimo**
+  - A suíte de testes passa a assumir recursos e semântica do Java 17.
+  - Enums de JRE anteriores (JAVA_8 ... JAVA_16) são descontinuados em anotações condicionais.
+
+- **Kotlin 2.2 mínimo (onde aplicável)**
+  - Alinha o suporte oficial do JUnit com versões modernas de Kotlin.
+
+- **Unificação de versões entre módulos**
+  - Platform, Jupiter e Vintage usam o mesmo número de versão (ex.: `6.0.1`).
+  - Facilita configuração via BOMs e reduz divergência entre módulos.
+
+- **Integração com JFR**
+  - Funcionalidades que antes dependiam de módulo separado (`junit-platform-jfr`) foram integradas ao `junit-platform-launcher`.
+
+### 4.2 JSpecify e nullability
+
+- Todos os módulos do JUnit 6 passam a utilizar anotações de nullability do [JSpecify](https://jspecify.dev/).
+- Benefícios práticos:
+  - Melhora a documentação do contrato das APIs.
+  - Ajuda ferramentas de análise estática a encontrar problemas de null mais cedo.
+
+### 4.3 Melhorias em Jupiter e ordenação
+
+- **Ordem determinística de `@Nested`**
+  - As classes internas anotadas com `@Nested` agora são executadas em ordem determinística (ainda que não óbvia).
+  - Reduz a chance de flakiness causada por dependência acidental de ordem.
+
+- **Orderers padrão para métodos e classes**
+  - `MethodOrderer.Default` e `ClassOrderer.Default` fornecem política padrão consistente de ordenação.
+  - `@TestMethodOrder` passa a ser herdado por classes `@Nested` anexas, simplificando a configuração.
+
+### 4.4 CSV e testes parametrizados
+
+- Migração do parser CSV interno para [FastCSV](https://fastcsv.org/):
+  - Melhor tratamento de headers em `@CsvSource` e `@CsvFileSource`.
+  - Detecção automática de quebras de linha (`\r`, `\n`, `\r\n`).
+  - Proibição de certos formatos de CSV malformados, evitando que entradas ambíguas passem silenciosamente.
+
+- Alguns atributos dessas anotações passam a se aplicar também a headers (por exemplo, `ignoreLeadingAndTrailingWhitespace`, `nullValues`).
+
+### 4.5 Execução e controle de fluxo
+
+- **Modo *fail-fast* no `ConsoleLauncher`**
+  - Novo parâmetro `--fail-fast` permite abortar a execução de testes ao primeiro erro.
+
+- **`CancellationToken` para cancelar execução**
+  - Novo mecanismo para sinalizar cancelamento de execução de testes.
+  - Útil em integrações com ferramentas que precisam interromper a suíte em tempo de execução.
+
+---
+
+## 5. Ganhos práticos para o projeto
+
+- **Alinhamento com stack moderna**
+  - Se o projeto já usa Java 17+ em produção, alinhar também os testes reduz discrepâncias entre ambientes.
+
+- **Menos risco de APIs obsoletas**
+  - Ao migrar para o JUnit 6, o time é forçado a remover usos de construções antigas que já estavam deprecated no JUnit 5.
+
+- **Manutenibilidade a longo prazo**
+  - O JUnit 6 é o alvo principal de evolução da plataforma de testes.
+  - Corrigir warnings de depreciação agora evita dor de cabeça em futuras versões.
+
+- **Melhor suporte a integrações**
+  - Ferramentas modernas (build, IDE, análise, observabilidade) tendem a focar suporte nas versões mais novas do JUnit.
+
+---
+
+## 6. Migração do JUnit 5 para o JUnit 6
+
+### 6.1 Visão geral da migração
+
+A migração de JUnit 5.x para 6.0.x foi pensada para ser **evolutiva**, não uma reescrita completa.
+
+Em resumo:
+
+- A estrutura conceitual (Platform, Jupiter, Vintage) é preservada.
+- A maior parte da API usada em testes de dia a dia continua igual.
+- A principal fonte de trabalho são **APIs e comportamentos marcados como deprecated** na série 5.x e efetivamente removidos na 6.x.
+
+Há um guia oficial de upgrade mantido pelo time do JUnit:
+ 
+ - [Upgrading to JUnit 6.0](https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-6.0)
+
+### 6.2 Pré-requisitos
+
+Antes de tentar subir para o JUnit 6, garantir que:
+
+- O projeto está em **Java 17 ou superior**.
+- Se houver código de teste em Kotlin, a versão de Kotlin atende o mínimo exigido (2.2 ou superior, conforme release notes atuais).
+
+### 6.3 Passos recomendados
+
+- **Passo 1 – Atualizar o JDK do projeto**
+  - Ajustar o toolchain do build (Maven/Gradle) para usar Java 17+.
+  - Garantir que a aplicação e os testes compilam e rodam normalmente com JUnit 5 ainda.
+
+- **Passo 2 – Atualizar as dependências do JUnit**
+  - Identificar hoje quais artefatos do JUnit 5 estão em uso (por exemplo, `junit-jupiter`, `junit-jupiter-params`, `junit-platform-launcher`, etc.).
+  - Atualizar essas mesmas dependências para a versão `6.0.x` correspondente.
+  - Se usar BOM, trocar o import do BOM da família 5.x para 6.x.
+
+- **Passo 3 – Rodar todos os testes e coletar erros de compilação/execução**
+  - Corrigir erros de compilação causados por remoção de APIs deprecated.
+  - Ajustar configurações de engine, plugins ou extensões que dependiam de comportamentos alterados.
+
+- **Passo 4 – Revisar usos de APIs sensíveis**
+  - Verificar anotações condicionais baseadas em `JRE` (por exemplo, `@EnabledOnJre`, `@DisabledOnJre`, `@EnabledForJreRange`, `@DisabledForJreRange`) que referenciem versões anteriores ao Java 17.
+  - Revisar testes parametrizados com `@CsvSource` e `@CsvFileSource` que dependam fortemente de detalhes de parsing.
+
+### 6.4 Mudanças e quebras mais comuns
+
+Abaixo alguns pontos que podem aparecer durante a migração (a lista não é exaustiva; consultar sempre os release notes oficiais para o conjunto completo).
+
+- **APIs de ordenação removidas ou alteradas**
+  - `MethodOrderer.Alphanumeric` foi removido.
+    - Substituir por um dos orderers atuais (`MethodOrderer.MethodName`, `MethodOrderer.OrderAnnotation`, `MethodOrderer.DisplayName`) ou pelo novo `MethodOrderer.Default`.
+
+- **Módulos de migração descontinuados**
+  - O módulo `junit-jupiter-migrationsupport` está deprecado e previsto para remoção em versões futuras.
+  - Evitar depender dele a longo prazo; preferir testes já nativos em Jupiter.
+
+- **Anotações condicionais com JRE antigos**
+  - Constantes `JRE.JAVA_8` até `JRE.JAVA_16` deixam de fazer sentido com baseline Java 17.
+  - Atualizar anotações como `@EnabledOnJre`, `@DisabledOnJre`, `@EnabledForJreRange`, `@DisabledForJreRange` para usar apenas versões suportadas (por exemplo, `JAVA_17` em diante).
+
+- **CSV e testes parametrizados**
+  - Erros de parsing passam a ser mais estritos em alguns casos (por exemplo, conteúdo extra após fechamento de aspas).
+  - O atributo `lineSeparator` em `@CsvFileSource` foi removido; a detecção agora é automática.
+  - Alguns atributos (como `ignoreLeadingAndTrailingWhitespace`, `nullValues`) agora também se aplicam aos headers, o que pode mudar levemente o comportamento esperado.
+
+- **Configurações estritas para enums**
+  - Valores inválidos em certas propriedades de configuração (por exemplo, relacionadas a paralelismo, timeouts, lifecycle) passam a causar falha de descoberta/execução de testes.
+  - É recomendável revisar configurações personalizadas usadas no projeto para garantir que os valores continuam válidos.
+
+### 6.5 Estratégia de migração gradual
+
+- **Começar pela atualização de ambiente (Java/Kotlin)**
+  - Mesmo antes de mexer em dependências do JUnit, subir o JDK do projeto para 17+ e ajustar o que for necessário.
+
+- **Atualizar JUnit em uma branch dedicada**
+  - Criar uma branch específica para a migração (evitar misturar com outras mudanças grandes).
+  - Rodar a suíte completa de testes, ajustando problemas conforme forem surgindo.
+
+- **Coletar conhecimento no time**
+  - Documentar no repositório (por exemplo, neste arquivo ou em um changelog) os pontos encontrados na migração.
+  - Reutilizar esse conhecimento para outros serviços/projetos da organização.
+
+### 6.6 Execução de testes no projeto (Gradle)
+
+No contexto deste projeto (módulo `app`), os testes estão organizados em duas categorias principais, ambas rodando sobre o JUnit 6:
+
+- Testes **unitários** e de uso de domínio/API (sem Testcontainers/Docker).
+- Testes **de integração** com infraestrutura real via Testcontainers (`@Tag("integration")`).
+
+Configuração relevante no `build.gradle` do módulo `app`:
+
+```groovy
+test {
+    useJUnitPlatform {
+        excludeTags 'integration'
+    }
+}
+
+tasks.register('integrationTest', Test) {
+    useJUnitPlatform {
+        includeTags 'integration'
+    }
+    // demais configurações (classpath, testClassesDirs, logging, etc.)
+}
+```
+
+Convenção de anotações nos testes:
+
+- Testes que usam **Testcontainers** e precisam de Docker (por exemplo, `OrderControllerIT`, `DeliveryApplicationTests`):
+
+  ```java
+  @SpringBootTest
+  @Testcontainers
+  @ActiveProfiles("test")
+  @Tag("integration")
+  class DeliveryApplicationTests { ... }
+  ```
+
+- Demais testes (unitários/domínio) não utilizam essa tag e portanto rodam apenas em `:app:test`.
+
+Como executar no dia a dia:
+
+- **Apenas testes unitários (sem Docker):**
+
+  ```bash
+  ./gradlew :app:test
+  ```
+
+- **Apenas testes de integração (requer Docker/Testcontainers):**
+
+  ```bash
+  ./gradlew :app:integrationTest
+  ```
+
+- **Pipeline completo (unitários + integração + checagens):**
+
+  ```bash
+  ./gradlew :app:clean :app:test :app:integrationTest :app:check
+  ```
+
+Essa organização funciona igualmente bem com JUnit 6, aproveitando o suporte a tags do Jupiter para separar claramente os ambientes de execução.
+
+---
+
+## 7. Referências oficiais
+
+- **User Guide (JUnit 6.0.1)**
+  - [docs.junit.org/current/user-guide](https://docs.junit.org/current/user-guide/)
+
+- **Release Notes (JUnit 6)**
+  - [docs.junit.org/current/release-notes](https://docs.junit.org/current/release-notes/index.html)
+
+- **Guia oficial de upgrade JUnit 5 → JUnit 6**
+  - [Upgrading to JUnit 6.0](https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-6.0)
+
+Essas referências devem ser consultadas sempre que surgirem dúvidas específicas sobre comportamentos, APIs removidas ou configurações avançadas. O objetivo deste documento é servir como visão geral e guia prático inicial para o time.

--- a/app/docs/guide/assertThat-vs-junit-assertions.md
+++ b/app/docs/guide/assertThat-vs-junit-assertions.md
@@ -1,10 +1,10 @@
-# assertThat (AssertJ) vs Assertivas do JUnit 5
+# assertThat (AssertJ) vs Assertivas do JUnit 5/6
 
-Este documento compara o uso de `assertThat` (AssertJ) com as assertivas padrão do JUnit 5 (`Assertions.assertEquals`, `assertTrue`, etc.), analisando vantagens, desvantagens e quando usar cada um.
+Este documento compara o uso de `assertThat` (AssertJ) com as assertivas padrão do JUnit 5/6 (`Assertions.assertEquals`, `assertTrue`, etc.), analisando vantagens, desvantagens e quando usar cada um.
 
 ## 1. Visão Geral
 
-- **JUnit 5 Assertions**
+- **JUnit 5/6 Assertions**
   - Fazem parte da própria biblioteca de testes JUnit.
   - Oferecem métodos como `assertEquals`, `assertTrue`, `assertThrows`, etc.
   - API simples e suficiente para muitos cenários.
@@ -16,7 +16,7 @@ Este documento compara o uso de `assertThat` (AssertJ) com as assertivas padrão
 
 ## 2. Legibilidade e Mensagens de Erro
 
-### JUnit 5
+### JUnit 5/6
 
 - Exemplo típico:
   - `assertEquals(expected, actual);`
@@ -35,7 +35,7 @@ Este documento compara o uso de `assertThat` (AssertJ) com as assertivas padrão
 
 ## 3. Cobertura de Tipos e Operações
 
-### JUnit 5
+### JUnit 5/6
 
 - Oferece uma base sólida para tipos primitivos, objetos e exceções.
 - Para coleções, streams e tipos mais ricos, normalmente é preciso combinar asserts genéricos:
@@ -81,13 +81,13 @@ No projeto atual:
 - Depende de biblioteca extra (já presente no projeto, então custo é baixo).
 - Mais API para aprender; pode ser demais para cenários muito simples.
 
-### Vantagens das asserts do JUnit 5
+### Vantagens das asserts nativas do JUnit 5/6
 
 - Nenhuma dependência adicional.
 - API conhecida e padrão da comunidade.
 - Ótimo para cenários simples e asserts pontuais.
 
-### Desvantagens das asserts do JUnit 5
+### Desvantagens das asserts nativas do JUnit 5/6
 
 - Menos expressivo para coleções e objetos complexos.
 - Código pode ficar mais verboso com muitos `assertEquals`/`assertTrue` sequenciais.
@@ -103,3 +103,39 @@ No projeto atual:
 
 - **Ponto de equilíbrio:**
   - Se o teste começa a acumular muitos asserts sobre o mesmo objeto ou lista, considere trocar para AssertJ para manter o código legível e alinhado com o estilo do projeto.
+
+## 7. Tabela de comparação detalhada (AssertJ vs JUnit 5/6)
+
+As tabelas abaixo resumem as principais diferenças entre usar `assertThat` (AssertJ) e as asserts nativas do JUnit 5/6.
+
+### 7.1 Visão geral
+
+| Aspecto | AssertJ (`assertThat`) | JUnit 5/6 (`Assertions.*`) |
+| --- | --- | --- |
+| Estilo de API | Fluente e encadeado, por exemplo `assertThat(x).isNotNull().isGreaterThan(10)` | Funções estáticas isoladas: `assertEquals`, `assertTrue`, `assertThrows`, etc. |
+| Leitura do teste | Mais próxima de linguagem natural, especialmente para coleções e objetos ricos | Pode ficar verboso quando há muitas asserts sobre o mesmo objeto ou lista |
+| Cobertura de tipos | API rica para coleções, mapas, `Optional`, datas, `BigDecimal`, `Path`, etc. | API genérica, focada em igualdade, nulidade e booleanos |
+| Mensagens de erro | Normalmente mais detalhadas, com diffs de coleções/mapas e indicação clara do que falhou | Mais simples; muitas vezes exige mensagem customizada para bom contexto |
+| Encadeamento | Permite várias verificações encadeadas sobre o mesmo alvo | Cada verificação é uma chamada de função independente |
+| Soft assertions | Possui `SoftAssertions` / `JUnitSoftAssertions` para acumular falhas | Não possui soft assertions nativas |
+| Estilo BDD | Suporta `BDDAssertions.then(...)` para estilo given/when/then | Não possui API específica de BDD |
+| Dependências | Requer dependência externa (AssertJ) | Já faz parte do JUnit 5/6 (nenhuma dependência extra) |
+
+### 7.2 O que o AssertJ oferece a mais que o JUnit 5/6
+
+| Categoria | AssertJ (`assertThat`) | Situação com JUnit 5/6 |
+| --- | --- | --- |
+| Coleções e mapas | Métodos como `hasSize`, `containsExactly`, `containsOnly`, `containsExactlyInAnyOrder`, `containsSubsequence`, `doesNotContain`, etc. | Normalmente combinações de `assertEquals`, `assertIterableEquals`, `assertTrue(lista.contains(...))`, mais verbosas |
+| Objetos complexos | `extracting`, `filteredOn`, `usingRecursiveComparison()` facilitam testar propriedades aninhadas e objetos ricos | Geralmente é necessário escrever código manual para montar o esperado e comparar campo a campo |
+| Tipos de domínio modernos | Assertions específicas para `Optional`, datas (`OffsetDateTime`, `LocalDateTime`), `Path`, `File`, `BigDecimal`, entre outros | Usa assertions genéricas (`assertEquals`, `assertNotNull`, `assertTrue`) sem semântica específica para o tipo |
+| Encadeamento de regras | Várias verificações sobre o mesmo alvo em uma única expressão de teste | Diversas chamadas de assertion espalhadas no método de teste |
+| Soft assertions | `SoftAssertions` permite ver várias falhas de uma vez em vez de parar na primeira | Requer `assertAll` com lambdas ou múltiplos testes para comportamento semelhante |
+
+### 7.3 O que o JUnit 5/6 oferece que o AssertJ não substitui
+
+| Categoria | JUnit 5/6 | Relação com AssertJ |
+| --- | --- | --- |
+| Assumptions | `Assumptions.assumeTrue/assumeFalse/assumeThat` para ignorar testes em determinadas condições | AssertJ não oferece assumptions; continuamos usando as do JUnit para controle de execução dos testes |
+| Controle de fluxo com exceções | `assertThrows` e `assertDoesNotThrow` definem claramente quando o teste deve falhar ou passar com base em exceções | AssertJ tem assertions de exceção (`assertThatThrownBy` etc.), mas não substitui o papel do `assertThrows` no fluxo do teste |
+| Integração com o framework | Assertions são parte oficial do JUnit Jupiter (5/6), integradas ao ecossistema (IDE, relatórios, exemplos oficiais) | AssertJ funciona em cima de qualquer framework de teste e complementa as asserts nativas |
+| `assertAll` | Permite agrupar várias assertions em lambdas, reportando todas as falhas de uma vez | Alternativa ao uso de `SoftAssertions`; escolha depende de estilo do time e do teste |

--- a/app/docs/guide/assertThat-vs-junit-assertions.md
+++ b/app/docs/guide/assertThat-vs-junit-assertions.md
@@ -1,0 +1,105 @@
+# assertThat (AssertJ) vs Assertivas do JUnit 5
+
+Este documento compara o uso de `assertThat` (AssertJ) com as assertivas padrão do JUnit 5 (`Assertions.assertEquals`, `assertTrue`, etc.), analisando vantagens, desvantagens e quando usar cada um.
+
+## 1. Visão Geral
+
+- **JUnit 5 Assertions**
+  - Fazem parte da própria biblioteca de testes JUnit.
+  - Oferecem métodos como `assertEquals`, `assertTrue`, `assertThrows`, etc.
+  - API simples e suficiente para muitos cenários.
+
+- **AssertJ (`assertThat`)**
+  - Biblioteca externa focada em assertions fluentes.
+  - API rica, com centenas de métodos específicos para tipos diferentes.
+  - Estilo encadeado: `assertThat(valor).isEqualTo(...).isGreaterThan(...)`.
+
+## 2. Legibilidade e Mensagens de Erro
+
+### JUnit 5
+
+- Exemplo típico:
+  - `assertEquals(expected, actual);`
+- Quando a verificação falha, a mensagem padrão é mais genérica.
+- Legibilidade cai quando há muitas verificações encadeadas:
+  - Vários `assertEquals`/`assertTrue` em sequência sobre o mesmo objeto.
+
+### AssertJ (`assertThat`)
+
+- Sintaxe fluente:
+  - `assertThat(pedido.getTotal()).isEqualTo(BigDecimal.TEN);`
+- Mensagens de falha mais ricas e específicas por tipo.
+- Facilita ler "em voz alta": "espera que total seja igual a 10".
+
+**Resumo:** para testes que precisam ser altamente legíveis e autoexplicativos, `assertThat` costuma produzir código mais claro.
+
+## 3. Cobertura de Tipos e Operações
+
+### JUnit 5
+
+- Oferece uma base sólida para tipos primitivos, objetos e exceções.
+- Para coleções, streams e tipos mais ricos, normalmente é preciso combinar asserts genéricos:
+  - `assertEquals(3, lista.size());`
+  - `assertTrue(lista.contains(x));`
+
+### AssertJ
+
+- API específica para:
+  - Coleções, mapas, `Optional`, `BigDecimal`, datas, exceções, etc.
+  - Verificações encadeadas em coleções (`hasSize`, `containsExactly`, `extracting`, ...).
+- Facilita expressar regras de negócio de forma direta:
+  - `assertThat(itens).hasSize(3).extracting(Item::getProdutoId).containsExactly(...);`
+
+**Resumo:** quando o teste envolve coleções, objetos complexos ou muitas propriedades, AssertJ reduz verbosidade e duplicação.
+
+## 4. Integração com o Ecossistema Atual
+
+No projeto atual:
+
+- Já usamos AssertJ em vários testes (`Assertions.assertThat(...)`).
+- Também usamos algumas asserts do JUnit (`assertThrows`, por exemplo, é muito útil e complementa AssertJ).
+
+**Padrão recomendado:**
+
+- Para **asserts de valor/estado** (equals, size, propriedades de objetos):
+  - Preferir `assertThat` (AssertJ).
+- Para **asserts de exceção**:
+  - Tanto `assertThrows` (JUnit) quanto `assertThatThrownBy` (AssertJ) são válidos.
+  - Manter consistência por classe de teste (evitar misturar estilos sem necessidade).
+
+## 5. Vantagens e Desvantagens Resumidas
+
+### Vantagens do AssertJ (`assertThat`)
+
+- API fluente e legível.
+- Suporte amplo a tipos complexos (coleções, mapas, opcionais, datas, BigDecimal).
+- Mensagens de erro mais claras, reduzindo tempo de debug.
+- Facilita testes com muitas verificações relacionadas ao mesmo objeto.
+
+### Desvantagens do AssertJ
+
+- Depende de biblioteca extra (já presente no projeto, então custo é baixo).
+- Mais API para aprender; pode ser demais para cenários muito simples.
+
+### Vantagens das asserts do JUnit 5
+
+- Nenhuma dependência adicional.
+- API conhecida e padrão da comunidade.
+- Ótimo para cenários simples e asserts pontuais.
+
+### Desvantagens das asserts do JUnit 5
+
+- Menos expressivo para coleções e objetos complexos.
+- Código pode ficar mais verboso com muitos `assertEquals`/`assertTrue` sequenciais.
+
+## 6. Guia Prático para o Projeto
+
+- **Novo teste de use case ou domínio:**
+  - Usar `assertThat` para verificar valores, coleções e propriedades.
+  - Usar JUnit (`assertThrows`) ou AssertJ (`assertThatThrownBy`) para exceções, mantendo consistência.
+
+- **Testes existentes só com JUnit:**
+  - Não é obrigatório migrar; apenas considere AssertJ ao refatorar ou estender o teste.
+
+- **Ponto de equilíbrio:**
+  - Se o teste começa a acumular muitos asserts sobre o mesmo objeto ou lista, considere trocar para AssertJ para manter o código legível e alinhado com o estilo do projeto.

--- a/app/src/test/java/com/poc/delivery/DeliveryApplicationTests.java
+++ b/app/src/test/java/com/poc/delivery/DeliveryApplicationTests.java
@@ -1,6 +1,7 @@
 package com.poc.delivery;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -13,6 +14,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest
 @Testcontainers
 @ActiveProfiles("test")
+@Tag("integration")
 class DeliveryApplicationTests {
 
     private static final String DEFAULT_DELIVERY_STRING = "delivery";

--- a/historias/fase1/historia-HIST-000-scaffold-backend.md
+++ b/historias/fase1/historia-HIST-000-scaffold-backend.md
@@ -14,7 +14,7 @@ Criar a base técnica do projeto backend, alinhada às decisões de stack e às 
 - Estrutura mínima de pacotes definida (api, application, domain, infrastructure).
 - Profile **`local`** configurado com `application-local.yml`.
 - Dependências principais adicionadas (Spring Web, Spring Data JPA, PostgreSQL, Redis, Actuator).
-- Ferramentas de qualidade configuradas (Checkstyle, JaCoCo, JUnit 5, Testcontainers, MapStruct, Instancio).
+- Ferramentas de qualidade configuradas (Checkstyle, JaCoCo, JUnit 6, Testcontainers, MapStruct, Instancio).
 - Projeto compila e sobe localmente (mesmo que com endpoints mínimos/health check).
 
 ## Tasks Técnicas
@@ -41,7 +41,7 @@ Criar a base técnica do projeto backend, alinhada às decisões de stack e às 
 - **T0.4 – Adicionar dependências principais**
   - Spring Web, Spring Data JPA, PostgreSQL, Spring Cache/Redis, Actuator.
   - MapStruct (API + annotation processor).
-  - JUnit 5, Testcontainers, RestAssured (se aplicável), Cucumber, Instancio.
+  - JUnit 6, Testcontainers, RestAssured (se aplicável), Cucumber, Instancio.
 
 - **T0.5 – Configurar ferramentas de qualidade**
   - Checkstyle (plugin Gradle + `checkstyle.xml`).

--- a/historias/fase1/historia-HIST-001-criacao-pedido.md
+++ b/historias/fase1/historia-HIST-001-criacao-pedido.md
@@ -47,5 +47,5 @@ Permitir que um cliente selecione uma loja, escolha produtos, informe endereço 
   - Retornar códigos HTTP apropriados (400/404/422) conforme o caso.
 
 - **T1.7 – Testes**
-  - Testes unitários (JUnit 5 + Instancio) para regras de negócio.
+  - Testes unitários (JUnit 6 + Instancio) para regras de negócio.
   - Testes de integração (Cucumber + Testcontainers + RestAssured) cobrindo fluxo de criação de pedido com sucesso e falhas de validação.

--- a/historias/fase1/historia-HIST-002-visualizacao-pedidos-loja.md
+++ b/historias/fase1/historia-HIST-002-visualizacao-pedidos-loja.md
@@ -34,5 +34,5 @@ Permitir que a loja consulte os pedidos associados a ela, com filtros por status
   - Tratar erros de parâmetros inválidos (datas, status) com `400 Bad Request`.
 
 - **T2.5 – Testes**
-  - Testes unitários (JUnit 5 + Instancio) para lógica de filtro e paginação (quando aplicável).
+  - Testes unitários (JUnit 6 + Instancio) para lógica de filtro e paginação (quando aplicável).
   - Testes de integração (Cucumber + Testcontainers + RestAssured) cobrindo cenários de listagem com filtros diferentes.

--- a/planejamento/requisitos-nao-funcionais-fase1.md
+++ b/planejamento/requisitos-nao-funcionais-fase1.md
@@ -196,8 +196,8 @@
   - Utilizar **Instancio** para criação de instâncias de objetos em testes automatizados, reduzindo boilerplate de montagem de dados.
   - Aplicar principalmente em testes de unidade e integração para gerar dados de entrada variados e focar a escrita do teste na lógica de negócio, e não na construção manual de objetos complexos.
 
-- **Framework de testes – JUnit 5**
-  - Utilizar **JUnit 5** como framework padrão para testes de unidade e integração.
+- **Framework de testes – JUnit 6**
+  - Utilizar **JUnit 6** como framework padrão para testes de unidade e integração.
   - Evitar misturar versões antigas (JUnit 4); novos testes devem seguir o modelo Jupiter (anotações `@Test`, `@Nested`, `@DisplayName`, etc.).
 
 ## 10. Ambiente de Desenvolvimento Local (Containers)

--- a/planejamento/tarefas-pre-implementacao-fase1.md
+++ b/planejamento/tarefas-pre-implementacao-fase1.md
@@ -78,7 +78,7 @@ Objetivo: garantir que o entendimento do domínio e das decisões técnicas este
 ## 6. Configurar Dependências de Testes
 
 - [ ] Adicionar dependências de testes no Gradle:
-  - [ ] **JUnit 5 (Jupiter)**.
+  - [ ] **JUnit 6 (Jupiter)**.
   - [ ] **Testcontainers** (PostgreSQL, Redis e outros necessários).
   - [ ] **Cucumber** (para testes BDD de integração, quando for utilizado).
   - [ ] **RestAssured** (para testes de API HTTP, quando fizer sentido).
@@ -113,7 +113,7 @@ Objetivo: garantir que o entendimento do domínio e das decisões técnicas este
 ## 9. Organizar Testes Iniciais (TDD)
 
 - [ ] Definir o primeiro conjunto de **casos de teste de negócio** para o domínio de pedidos (ex.: criação de pedido, mudança de status).
-- [ ] Criar **esqueleto de teste unitário** com JUnit 5 para pelo menos um caso crítico (por exemplo, cálculo de total do pedido com taxa de entrega e desconto).
+- [ ] Criar **esqueleto de teste unitário** com JUnit 6 para pelo menos um caso crítico (por exemplo, cálculo de total do pedido com taxa de entrega e desconto).
 - [ ] Criar **esqueleto de teste de integração** (Cucumber + Testcontainers + RestAssured) para um fluxo simples de criação e consulta de pedido (mesmo que ainda não implementado).
 
 ---


### PR DESCRIPTION
## Contexto

- **Objetivo**  
  Migrar a stack de testes do projeto para JUnit 6, reforçando a separação entre testes unitários e de integração e melhorando a documentação de boas práticas de testes e assertions.

- **Motivação**  
  - Alinhar o projeto com o ecossistema JUnit mais recente (Java 17+).  
  - Facilitar a manutenção de testes e a execução seletiva (unit vs integration).  
  - Fornecer documentação clara para onboarding e migração de outros projetos.

---

### Principais mudanças

- **Adicionado**
  - **Guia de Migração e Uso do JUnit 6**  
    - Novo documento `app/docs/guide/JUnit6.md` com:
      - Visão geral do JUnit 6 e principais diferenças em relação ao JUnit 5.
      - Vantagens da migração para projetos Java 17+.
      - Passo a passo de migração com foco em Gradle.
  - **Documentação aprimorada de assertions**  
    - Atualização do guia `assertThat-vs-junit-assertions.md` com:
      - Comparação entre AssertJ e assertions nativas do JUnit 5/6.
      - Tabelas destacando capacidades em coleções, mensagens de erro, soft assertions, BDD, etc.

- **Alterado**
  - **Stack de testes atualizada para JUnit 6**
    - Uso do BOM `org.junit:junit-bom:6.0.1` para alinhar Platform, Jupiter e Vintage na mesma versão.
    - Adequação dos testes existentes para rodarem sobre JUnit 6 sem alterar regras de negócio.
  - **Separação clara entre testes unitários e de integração**
    - Configuração Gradle ajustada para uso de tags do JUnit Jupiter:
      - `:app:test` executa apenas testes sem `@Tag("integration")`.
      - `:app:integrationTest` executa somente testes com `@Tag("integration")` (ex.: `OrderControllerIT`, `DeliveryApplicationTests`).
    - Testes de integração passam a depender explicitamente de Testcontainers/Docker, evitando falhas locais na suíte unitária.

---

### Como testar

- **Rodar testes unitários**
  - `./gradlew :app:test`
  - Esperado: todos os testes passando em ambiente local sem necessidade de Docker.

- **Rodar testes de integração**
  - Garantir Docker em execução.
  - `./gradlew :app:integrationTest`
  - Esperado: testes de integração sobem corretamente containers necessários e passam sem falhas.

- **Validar documentação**
  - Abrir `app/docs/guide/JUnit6.md` e `assertThat-vs-junit-assertions.md` e verificar:
    - Clareza do fluxo de migração.
    - Exemplos alinhados com a versão efetivamente utilizada no projeto.

---

### Checklist

- [ ] Código de build atualizado para usar BOM do JUnit 6 (`org.junit:junit-bom:6.0.1`).
- [ ] Todos os testes unitários passando com `./gradlew :app:test`.
- [ ] Todos os testes de integração passando com `./gradlew :app:integrationTest`.
- [ ] Documentos `JUnit6.md` e `assertThat-vs-junit-assertions.md` revisados.
- [ ] `CHANGELOG.md` atualizado com a versão `0.3.0`.  
